### PR TITLE
Users can now choose which file extensions to count.

### DIFF
--- a/lineCounter.py
+++ b/lineCounter.py
@@ -2,16 +2,21 @@ import os
 import sys
 import argparse
 
-def count_total_lines(directory_path, extensions):
+def count_total_lines(directory_path, extensions, include_hidden=False):
     print(f"Counting total lines of code in {directory_path}...")
-    total_lines = process_subdirectories(directory_path, extensions)
+    total_lines = process_subdirectories(directory_path, extensions, include_hidden)
     print(f"Total lines of code: {total_lines}")
 
-def process_subdirectories(directory_path, extensions):
+def process_subdirectories(directory_path, extensions=None, include_hidden=False):
     total_lines = 0
-    for root, _, files in os.walk(directory_path):
+    for root, dirs, files in os.walk(directory_path):
+        if not include_hidden:
+            dirs[:] = [d for d in dirs if not d.startswith('.')]
+
         for file in files:
-            if any(file.lower().endswith(ext) for ext in extensions):
+            if not include_hidden and file.startswith('.'):
+                continue
+            if extensions is None or any(file.lower().endswith(ext) for ext in extensions):
                 file_path = os.path.join(root, file)
                 with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                     total_lines += len(f.readlines())
@@ -24,8 +29,10 @@ def main():
         epilog="Example: python main.py /my/code --ext .py .cs .js"
     )
     parser.add_argument("directory", nargs="?", help="Path to the directory to scan")
-    parser.add_argument("--ext", nargs="+", default=[".py", ".cs"],
-                        help="File extensions to include (e.g., --ext .py .cs)")
+    parser.add_argument("--ext", nargs="+", default=None,
+                        help="File extensions to include (e.g., --ext .py .cs). If not provided, all files are counted.")
+    parser.add_argument("--include-hidden", action="store_true",
+                        help="Include hidden files and directories (default: false)")
 
     args = parser.parse_args()
 
@@ -33,7 +40,7 @@ def main():
         parser.print_help()
         sys.exit(0)
 
-    count_total_lines(args.directory, args.ext)
+    count_total_lines(args.directory, args.ext if args.ext else [".py", ".cs"], args.include_hidden)
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
 If none are passed in, then all files are counted. Also added in functionality to count all file types by default, but allow the user to pass in a list of specific extensions they'd like counted